### PR TITLE
Output tiffs as 16-bit floats

### DIFF
--- a/imgreg/multi_spect_image_io.py
+++ b/imgreg/multi_spect_image_io.py
@@ -18,7 +18,7 @@ def save_tif_image(image, output_path, filename, channel_names):
 	for i in range(len(channel_names)):
 		out_img = np.zeros(shape=(h,w,1))
 		out_img[:,:,0] = image[:,:,i]
-		out_img = out_img.astype(np.uint16)
+		out_img = out_img.astype(np.float16)
 		cv2.imwrite(os.path.join(output_path, channel_names[i], filename), out_img)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgreg"
-version = "0.1.0"
+version = "1.1.1"
 description = ""
 authors = ["Your Name <you@example.com>"]
 


### PR DESCRIPTION
It is possible for tiffs to represent pixel values as floats. In the case of py-6x-corrections, tiffs are output with float pixel values from 0 to 1. Outputting these pixel values as uint16s causes every value to round to 0, but simply changing the output format allows py-image-registration to output valid tiffs for float and integer inputs. Also, pyproject version was corrected from v0.1.1 to v1.1.1